### PR TITLE
Improve solution

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -9,12 +9,6 @@ const queries = require('./queries');
 // =========================================================
 // Routes
 // =========================================================
-router.get('/facsters', (req, res, next) =>
-  queries
-    .getAll()
-    .then(users => res.status(200).json(users))
-    .catch(err => next(err))
-);
 
 router.get('/facsters', (req, res, next) =>
   queries

--- a/solution-files/routes.test.js
+++ b/solution-files/routes.test.js
@@ -13,7 +13,7 @@ test('All routes should return the expected results', t => {
     .expect(200)
     .expect('Content-Type', /json/)
     .end((err, res) => {
-      t.error(err, 'No error');
+      t.error(err);
       t.end();
     });
 });
@@ -23,7 +23,7 @@ test('First User Should be Abdullah', t => {
     .expect(200)
     .expect('Content-Type', /json/)
     .end((err, res) => {
-      t.error(err, 'No error');
+      t.error(err);
       t.same(res.body[0].firstname, 'Abdullah');
       t.end();
     });
@@ -36,7 +36,7 @@ test('Should be able to get a facster by their name', t => {
       .expect(200)
       .expect('Content-Type', /json/)
       .end((err, res) => {
-        t.error(err, 'No error');
+        t.error(err);
         t.same(res.body[0].firstname, name, `Name is ${name} as expected`);
         if (names.length - 1 === index) {
           t.end();
@@ -52,7 +52,7 @@ test('Should add a new facster', t => {
     .expect(201)
     .expect('Content-Type', /json/)
     .end((err, res) => {
-      t.error(err, 'No error');
+      t.error(err);
       t.same(res.body[0].firstname, 'jason', 'Should add JSON bourne to FAC');
       t.end();
     });
@@ -63,7 +63,7 @@ test('Should find a facsters\' hobbies', t => {
     .expect(200)
     .expect('Content-Type', /json/)
     .end((err, res) => {
-      t.error(err, 'No error');
+      t.error(err);
       t.same(
         res.body[0].hobby,
         'Ninja training',
@@ -78,7 +78,7 @@ test('That it returns a given facster\'s superpower', t => {
     .expect(200)
     .expect('Content-Type', /json/)
     .end((err, res) => {
-      t.error(err, 'No error');
+      t.error(err);
       t.same(
         res.body[0].superpower,
         'linting wizard',

--- a/solution-files/routes.test.js
+++ b/solution-files/routes.test.js
@@ -1,3 +1,7 @@
+const tape = require('tape');
+const supertest = require('supertest');
+
+//Fill this with many many tests YAY!! 😜😩
 const test = require('tape');
 
 const request = require('supertest');
@@ -9,7 +13,6 @@ test('All routes should return the expected results', t => {
     .expect(200)
     .expect('Content-Type', /json/)
     .end((err, res) => {
-      t.same(res.statusCode, 200, 'Status code is 200');
       t.error(err, 'No error');
       t.end();
     });
@@ -20,7 +23,6 @@ test('First User Should be Abdullah', t => {
     .expect(200)
     .expect('Content-Type', /json/)
     .end((err, res) => {
-      t.same(res.statusCode, 200, 'Status code is 200');
       t.error(err, 'No error');
       t.same(res.body[0].firstname, 'Abdullah');
       t.end();
@@ -34,7 +36,6 @@ test('Should be able to get a facster by their name', t => {
       .expect(200)
       .expect('Content-Type', /json/)
       .end((err, res) => {
-        t.same(res.statusCode, 200, 'Status code is 200');
         t.error(err, 'No error');
         t.same(res.body[0].firstname, name, `Name is ${name} as expected`);
         if (names.length - 1 === index) {
@@ -51,7 +52,6 @@ test('Should add a new facster', t => {
     .expect(201)
     .expect('Content-Type', /json/)
     .end((err, res) => {
-      t.same(res.statusCode, 201, 'Status code is 201');
       t.error(err, 'No error');
       t.same(res.body[0].firstname, 'jason', 'Should add JSON bourne to FAC');
       t.end();
@@ -63,7 +63,6 @@ test('Should find a facsters\' hobbies', t => {
     .expect(200)
     .expect('Content-Type', /json/)
     .end((err, res) => {
-      t.same(res.statusCode, 200, 'Status code is 200');
       t.error(err, 'No error');
       t.same(
         res.body[0].hobby,
@@ -79,7 +78,6 @@ test('That it returns a given facster\'s superpower', t => {
     .expect(200)
     .expect('Content-Type', /json/)
     .end((err, res) => {
-      t.same(res.statusCode, 200, 'Status code is 200');
       t.error(err, 'No error');
       t.same(
         res.body[0].superpower,


### PR DESCRIPTION
#17 

Remove duplicated status code tests:
- supertest ```expect``` allows for testing of statuscodes, and passes an error to its ```.end``` if expected status code does not match actual, making it unnecessary to also test with tape inside the ```.end```.

Remove unnecessary message from ```t.error```:
- tape's ```.error``` method will [use the error's default message](https://github.com/substack/tape#terrorerr-msg) to show in the test results if no other message is provided, assuming that the error message is informative (as it is with supertest), this is actually better than having a generic 'No error' message.

EDIT:

#20 
Remove duplicate route (sorry should have been a separate PR!).