### PR TITLE
update supertest and tape variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ app.use('/api/v1/', routes)
 
 * 'Integration tests' are tests that check the correct functioning of several interconnected functions all working together.
 
+* `Supertest` and `Tape` allow us to perform Integration tests checking that the Server and Database are communicating properly, and calls to the Server endpoints respond with the correct status codes and any data requested.  
+
 * In the server folder there is a `routes` subfolder inside of which all the
   servers routes have been written for you (using promises).
 
@@ -51,10 +53,10 @@ app.use('/api/v1/', routes)
 * [Postman](https://www.getpostman.com/) is a tool which allows you to test
   api endpoints to see what these return.
 * An alternative is that you can use `curl` a command line took to ping an
-  endpoint for example 
+  endpoint for example
   ```sh
    curl http://www.example.org:1234/
-  ``` 
+  ```
   to check each endpoint (though
   this is slighty more involved and I recommend downloading postman).
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "nodemon ./server/",
-    "test": "node ./server/tests/routes.test.js | tap-spec",
-    "test:watch": "tape -w",
+    "test": "node ./server/tests/routes.test.js | tap-spec",    
     "build:db": "node ./database/dbBuild.js"
   },
   "repository": {

--- a/server/tests/routes.test.js
+++ b/server/tests/routes.test.js
@@ -1,4 +1,5 @@
-const tape = require('tape');
-const supertest = require('supertest');
+const test = require('tape');
+const request = require('supertest');
+const app = require('../server');
 
 //Fill this with many many tests YAY!! 😜😩

--- a/solution-files/routes.test.js
+++ b/solution-files/routes.test.js
@@ -1,9 +1,5 @@
-const tape = require('tape');
-const supertest = require('supertest');
-
 //Fill this with many many tests YAY!! 😜😩
 const test = require('tape');
-
 const request = require('supertest');
 const app = require('./../server');
 


### PR DESCRIPTION
In this PR:
- Update supertest and tape variable names to be consistent (closes #23), eg:
```
const test = require('tape');
const request = require('supertest');
```
- required in `app` in default setup for `routes.test.js`, as there are no instructions in `readme` to do this
- Removed duplicate `supertest` and `tape` inside solutions file (closes #27) 
- Removed `"test:watch": "tape -w"` script from `package.json`, this doesn't seem to work. Research suggests that you'd need a separate module for running `tape` in watch mode ie: `npm install tape-watch` (see [here](https://www.npmjs.com/package/tape-watch)) 
- Update `README` with additional point to explain how `supertest` and `tape` are being used to perform Integration tests (closes #24)